### PR TITLE
Feature/m123

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,12 @@ ENV LD_LIBRARY_PATH /usr/local/lib/:$LD_LIBRARY_PATH
 
 WORKDIR /home/webrtc_ws
 COPY . /home/webrtc_ws/src/
+RUN rm -rf /home/webrtc_ws/src/webrtc_ros
 
 RUN git clone https://github.com/GT-RAIL/async_web_server_cpp.git /home/webrtc_ws/src/async_web_server_cpp/
 
 RUN /ros_entrypoint.sh catkin_make_isolated --install --install-space "/usr/local/webrtc/" \
     && sed -i '$isource "/usr/local/webrtc/setup.bash"' /ros_entrypoint.sh \
     && rm -rf /home/webrtc_ws/
-
+    
 ENTRYPOINT ["/ros_entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,4 @@ RUN git clone https://github.com/GT-RAIL/async_web_server_cpp.git /home/webrtc_w
 RUN /ros_entrypoint.sh catkin_make_isolated --install --install-space "/usr/local/webrtc/" \
     && sed -i '$isource "/usr/local/webrtc/setup.bash"' /ros_entrypoint.sh \
     && rm -rf /home/webrtc_ws/
-    
 ENTRYPOINT ["/ros_entrypoint.sh"]

--- a/webrtc/CMakeLists.txt
+++ b/webrtc/CMakeLists.txt
@@ -40,6 +40,15 @@ execute_process(
 if(NOT ${get_webrtc_source_result} EQUAL 0)
     message(FATAL_ERROR "cannot fetch WebRTC source code")
 endif()
+message(STATUS "including builtin video codec library")
+execute_process(
+    COMMAND "build/include_builtin_video_codecs"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    RESULT_VARIABLE include_builtin_video_codecs_result
+)
+if(NOT ${include_builtin_video_codecs_result} EQUAL 0)
+    message(FATAL_ERROR "Failed to include builin video codec library as part of build!")
+endif()
 
 message(STATUS "Fetching GN build tool from Google")
 execute_process(

--- a/webrtc/build/get_webrtc_source
+++ b/webrtc/build/get_webrtc_source
@@ -2,7 +2,7 @@
 set -e
 run_updates=0
 rootdir="$(cd "$(dirname "$0")"; pwd)"
-revision="src@0a3d3093dfe54af40bbcb9354fe5661386cd6e48" # Chromium 103
+revision="src@41b1493ddb5d98e9125d5cb002fd57ce76ebd8a7" # Chromium 123
 export PATH="$rootdir/depot_tools:$PATH"
 if [ ! -d "$rootdir/webrtc" ]
 then

--- a/webrtc/build/include_builtin_video_codecs
+++ b/webrtc/build/include_builtin_video_codecs
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+rootdir="$(cd "$(dirname "$0")"; pwd)"
+export PATH="${rootdir}/depot_tools:$PATH"
+cd "$rootdir/webrtc/src"
+echo "$rootdir"
+
+# build.gn file
+build_gn_file="BUILD.gn"
+
+# Sed commands to add dependencies section after deps section in webrtc target
+sed -i '/rtc_static_library("webrtc") {/,/^ *}/ {
+  /deps = \[/a\ \ \ \ \ \ "api/video_codecs:builtin_video_decoder_factory",\n\ \ \ \ \ \ "api/video_codecs:builtin_video_encoder_factory",
+}' "$build_gn_file"
+
+echo "Updated build.gn file with new dependencies section for webrtc target."

--- a/webrtc/build/include_builtin_video_codecs
+++ b/webrtc/build/include_builtin_video_codecs
@@ -3,7 +3,6 @@ set -e
 rootdir="$(cd "$(dirname "$0")"; pwd)"
 export PATH="${rootdir}/depot_tools:$PATH"
 cd "$rootdir/webrtc/src"
-echo "$rootdir"
 
 # build.gn file
 build_gn_file="BUILD.gn"


### PR DESCRIPTION
This PR contains the code to upgrade the version of webrtc to m123. 
This includes adding a script that will edit the webrtc source's root BUILD.gn to include builtin video codecs that was removed in this [PR](https://webrtc.googlesource.com/src.git/+/2b00c4e1af8c79d7923fd2e4f11dd2329d47b0ee%5E%21/) 
Dockerfile was also edited to remove webrtc_ros before building as it is not needed for installing webrtc, and also crashes.